### PR TITLE
[BE] Strategy role definition

### DIFF
--- a/_docs/backenders/strategy-2021/roles/index.md
+++ b/_docs/backenders/strategy-2021/roles/index.md
@@ -13,6 +13,7 @@ You'll find here the definition of the different roles and the actual representa
 |:--|:--|
 | [template](/devismos/docs/backenders/strategy-2021/roles/template) | --- |
 | [BD proposals](/devismos/docs/backenders/strategy-2021/roles/business-development-proposals) | --- |
+| [Strategy](/devismos/docs/backenders/strategy-2021/roles/strategy) | --- |
 
 Related documents:
 

--- a/_docs/backenders/strategy-2021/roles/index.md
+++ b/_docs/backenders/strategy-2021/roles/index.md
@@ -13,7 +13,7 @@ You'll find here the definition of the different roles and the actual representa
 |:--|:--|
 | [template](/devismos/docs/backenders/strategy-2021/roles/template) | --- |
 | [BD proposals](/devismos/docs/backenders/strategy-2021/roles/business-development-proposals) | --- |
-| [Strategy](/devismos/docs/backenders/strategy-2021/roles/strategy) | --- |
+| [Strategy](/devismos/docs/backenders/strategy-2021/roles/strategy) | Agnieszka Figiel |
 
 Related documents:
 

--- a/_docs/backenders/strategy-2021/roles/strategy.md
+++ b/_docs/backenders/strategy-2021/roles/strategy.md
@@ -1,28 +1,24 @@
 ---
 layout: default
-title: Strategy Role
+title: Strategy & Contract Facelift Facilitator
 parent: Roles
 grand_parent: Strategy 2021
 ---
 
-# Strategy role definition
+# Strategy & Contract Facelift Facilitator role definition
 
-**Current responsible**: N/A
+**Current responsible**: Agnieszka Figiel
 
 ## Responsibilities
 
--  Drive the creation of the 2021 BE strategy and contract (high)
--  Seek external advice on the strategy and contract (other FAs, execs) (high)
--  Review new initiatives to ensure alignment with BE strategy (high / med)
--  Communicate the final version of the strategy and contract externally (update the BE repo, write a blog post) (med)
--  Consolidate and keep up to date "how we work" and "our values" documents (med)
+-  Drive the creation of the 2021 BE strategy and contract
+-  Seek external advice on the strategy and contract (other FAs, execs)
+-  Communicate the final version of the strategy and contract externally (update the BE repo, write a blog post)
 
 ## Impact
 
--  Increase awareness of BE FA's needs and commitments
--  Ensure alignment of initiatives with the strategy
--  Reduce team stress level by focusing on selected initiatives
+-  Increase awareness of BE FA's needs and committments
 -  Improve adoption of commitments and agreements
 
 ## Decision making
--  Involved in advice process for new initiatives, to ensure alignment with strategy
+-  New strategy and contract will be adopted through consent within the BE FA, with advice from other FAs and execs

--- a/_docs/backenders/strategy-2021/roles/strategy.md
+++ b/_docs/backenders/strategy-2021/roles/strategy.md
@@ -19,7 +19,7 @@ grand_parent: Strategy 2021
 
 ## Impact
 
--  Increase awareness of BE FA's needs and committments
+-  Increase awareness of BE FA's needs and commitments
 -  Ensure alignment of initiatives with the strategy
 -  Reduce team stress level by focusing on selected initiatives
 -  Improve adoption of commitments and agreements

--- a/_docs/backenders/strategy-2021/roles/strategy.md
+++ b/_docs/backenders/strategy-2021/roles/strategy.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Strategy Role
+parent: Roles
+grand_parent: Strategy 2021
+---
+
+# Strategy role definition
+
+**Current responsible**: N/A
+
+## Responsibilities
+
+-  Drive the creation of the 2021 BE strategy and contract (high)
+-  Seek external advice on the strategy and contract (other FAs, execs) (high)
+-  Review new initiatives to ensure alignment with BE strategy (high / med)
+-  Communicate the final version of the strategy and contract externally (update the BE repo, write a blog post) (med)
+-  Consolidate and keep up to date "how we work" and "our values" documents (med)
+
+## Impact
+
+-  Increase awareness of BE FA's needs and committments
+-  Ensure alignment of initiatives with the strategy
+-  Reduce team stress level by focusing on selected initiatives
+-  Improve adoption of commitments and agreements
+
+## Decision making
+-  Involved in advice process for new initiatives, to ensure alignment with strategy


### PR DESCRIPTION
Description for a role which originally was based on the Strategy role in FE, but ended up being a more limited role focused only on updating the 2021 strategy and contract.